### PR TITLE
docs:fix editurl the default value is facebook ,correct is devstream

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,13 +26,13 @@ const config = {
           routeBasePath: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+          editUrl: 'https://github.com/devstream-io/www/tree/main/',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/devstream-io/www/tree/main/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,13 +26,13 @@ const config = {
           routeBasePath: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/devstream-io/www/tree/main/',
+          editUrl: 'https://github.com/devstream-io/website/tree/main/',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            'https://github.com/devstream-io/www/tree/main/',
+            'https://github.com/devstream-io/website/tree/main/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
fix "edit the page" redirect error: 
on docs/blog page: clike button "
![image](https://user-images.githubusercontent.com/103085894/163924789-27243a2d-20ba-47dc-ab74-37d57de288b3.png)
",  will redirect to facebook :
![image](https://user-images.githubusercontent.com/103085894/163924860-ffe0ee33-e0d4-4da7-90a5-9d83c3720edc.png)

after fix: 

![image](https://user-images.githubusercontent.com/103085894/163924909-548641bf-2939-4f5f-9fdc-d77366e72dbd.png)
