### PR TITLE
fix: a slip of the pen: image alt effect display should be cncf not apache

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -154,7 +154,7 @@ const config = {
           },
         ],
         copyright: `
-        <img style="height:50px; margin-bottom: 10px; margin-top: 10px" alt="Apache Software Foundation" src= "/img/cncf-white-logo.svg" />
+        <img style="height:50px; margin-bottom: 10px; margin-top: 10px" alt="Cloud Native Computing Foundation" src= "/img/cncf-white-logo.svg" />
         <br />
         We are a Cloud Native Computing Foundation sandbox project.
         <br />


### PR DESCRIPTION
Signed-off-by: KeHaoKH <hao.ke@merico.dev>

# Summary 

fix alt msg: a slip of the pen


**Before**
 <alt="Apache Foundation" src= "/img/cncf-white-logo.svg" />


**After**

<alt="Cloud Native Computing Foundation" src= "/img/cncf-white-logo.svg" />

